### PR TITLE
Specify dependabot day and time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Oslo"
     groups:
       otel:
         patterns:
@@ -12,6 +15,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Oslo"
     groups:
       gh-actions:
         patterns:
@@ -20,6 +26,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Oslo"
     groups:
       docker:
         patterns:


### PR DESCRIPTION
Prevents dependabot merging and rolling out changes in the middle of the night.