### PR TITLE
fix(chart): use correct aivenapp spec

### DIFF
--- a/charts/wonderwall/templates/_resources.yaml
+++ b/charts/wonderwall/templates/_resources.yaml
@@ -69,7 +69,7 @@ Expects a dict as input with the following keys:
 {{- $secretName := .secretName -}}
 {{- $instance := include "aiven.instanceName" (dict "provider" $provider "root" $root) }}
 ---
-apiVersion: aiven.nais.io/v1
+apiVersion: aiven.nais.io/v2
 kind: AivenApplication
 metadata:
   name: {{ $instance }}-{{ $access }}
@@ -80,6 +80,6 @@ spec:
   valkey:
     - access: {{ $access }}
       instance: {{ $instance }}
-  secretName: {{ $secretName }}
+      secretName: {{ $secretName }}
   protected: true
 {{- end }}


### PR DESCRIPTION
Disse feiler nå med:

> operation CreateSecret failed: valkey.ValkeyHandler: operation GetOrInitSecret failed in Aiven: invalid secret name '': ErrUnrecoverable: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]